### PR TITLE
Rename project

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-name: auth-proxy
-version: 0.5.0
+name: helm-keycloak-gatekeeper
+version: 0.6.0
 kubeVersion: ">=1.10.0"
 description: Authenticating proxy, based on keycloak/keycloak-gatekeeper
 keyworkds:
@@ -8,8 +8,8 @@ keyworkds:
 - oidc
 - openid
 - keycloak
-home: https://github.com/mvitale1989/auth-proxy
+home: https://github.com/mvitale1989/helm-keycloak-gatekeeper
 maintainers:
 - name: mvitale1989
   email: mvitale1989@hotmail.com
-appVersion: "v2.3.0"
+appVersion: "5.0.0"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: auth-proxy
 version: 0.5.0
 kubeVersion: ">=1.10.0"
-description: Authenticating proxy, based on gambol99/keycloak-proxy
+description: Authenticating proxy, based on keycloak/keycloak-gatekeeper
 keyworkds:
 - sso
 - oidc

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # auth-proxy
-A helm chart for installing an authenticating proxy in front of your kubernetes services. Based on the excellent [gambol99/keycloak-proxy](https://github.com/gambol99/keycloak-proxy).
+A helm chart for installing an OpenID Connect authenticating proxy in front of your HTTP services. Based on the excellent [keycloak/keycloak-gatekeeper](https://github.com/keycloak/keycloak-gatekeeper).
 
 ### How it works
 
-This charts installs a service, and optionally also an ingress, that sits between the a _service_ (e.g. a Kubernetes dashboard) and its clients, allowing incoming requests only if they've been authenticated by an OIDC provider of your choice.
+This charts installs a service, and optionally also an ingress, that sits between a _service_ (e.g. an internal ClusterIP service) and its clients, allowing incoming requests only if they've been authenticated by an OIDC provider of your choice.
 
 ### Example configuration
 
 The following `values.yaml` lets you protect requests to the in-cluster service `my-service`, given a proper configuration of your IdP (e.g. registration of the `my-service` client, generation of a client-secret, etc):
 
 ```
-upstreamServiceName: "my-service"
+upstreamUrl: "http://my-service:8080"
 
 oidc:
   clientId: "my-service"
@@ -34,7 +34,7 @@ Check out `values.yaml` for other options tha are configurable in this chart.
 
 ### Future work
 
-- Expose distributed caching flags, already implemented in gambol99/keycloak-proxy (e.g. `--store-url=redis://127.0.0.1:6379`)
+- Expose distributed caching flags, already implemented in keycloak/keycloak-gatekeeper (e.g. `--store-url=redis://127.0.0.1:6379`)
 - Expose optional prometheus endpoint, through flags and proper pod/service configuration
 - Expose tags flag, for configuring the forbidden/login templates
 - Add option for specifying the redirect URL e.g. for logouts

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# auth-proxy
+# helm-keycloak-gatekeeper
 A helm chart for installing an OpenID Connect authenticating proxy in front of your HTTP services. Based on the excellent [keycloak/keycloak-gatekeeper](https://github.com/keycloak/keycloak-gatekeeper).
 
 ### How it works

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,4 +1,4 @@
-The auth-proxy is now ready, in front of service {{ .Values.upstreamServiceName }}. You can now:
+The auth-proxy is now ready, in front of URL {{ .Values.upstreamUrl }}. You can now:
 - Check out the status of the auth-proxy deployment: `kubectl describe deployment {{ include "auth-proxy.fullname" . }}`
 - Access the auth-proxy internally, at service {{ include "auth-proxy.fullname" . }}, port {{ .Values.service.port }}
 {{ if .Values.ingress.enabled }}- Access the auth-proxy externally, at names: {{ .Values.ingress.hosts | join "," }}{{ end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,5 +1,5 @@
-The auth-proxy is now ready, in front of URL {{ .Values.upstreamUrl }}. You can now:
-- Check out the status of the auth-proxy deployment: `kubectl describe deployment {{ include "auth-proxy.fullname" . }}`
-- Access the auth-proxy internally, at service {{ include "auth-proxy.fullname" . }}, port {{ .Values.service.port }}
-{{ if .Values.ingress.enabled }}- Access the auth-proxy externally, at names: {{ .Values.ingress.hosts | join "," }}{{ end }}
+keycloak-gatekeeper is now ready, in front of URL {{ .Values.upstreamUrl }}. You can now:
+- Check out the status of the keycloak-gatekeeper deployment: `kubectl describe deployment {{ include "keycloak-gatekeeper.fullname" . }}`
+- Access keycloak-gatekeeper internally, at service {{ include "keycloak-gatekeeper.fullname" . }}, port {{ .Values.service.port }}
+{{ if .Values.ingress.enabled }}- Access keycloak-gatekeeper externally, at names: {{ .Values.ingress.hosts | join "," }}{{ end }}
 {{ if .Values.ingress.tls }}- Access or write out the TLS secrets, in the objects: {{ range .Values.ingress.tls }}{{ .secretName }}, {{ end }} {{ end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,20 +1,20 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/* Create a default fully qualified app name. */}}
-{{- define "auth-proxy.fullname" -}}
+{{- define "keycloak-gatekeeper.fullname" -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* Create chart name and version as used by the chart label. */}}
-{{- define "auth-proxy.chart" -}}
+{{- define "keycloak-gatekeeper.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/* Labels to attach to every auth-proxy object. */}}
-{{- define "auth-proxy.labels" -}}
+{{/* Labels to attach to every keycloak-gatekeeper object. */}}
+{{- define "keycloak-gatekeeper.labels" -}}
 heritage: {{ .Release.Service }}
 release: {{ .Release.Name }}
-chart: {{ include "auth-proxy.chart" . }}
+chart: {{ include "keycloak-gatekeeper.chart" . }}
 {{ if .Values.extraLabels -}}
 {{ .Values.extraLabels | toYaml }}
 {{- end -}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "auth-proxy.labels" . | indent 4 }}
 data:
   forbidden-page: |
-{{ .Values.proxyOptions.forbiddenPageTemplate | default ( include "defaultForbiddenPage" . ) | indent 4 }}
+{{ .Values.proxyOptions.userFriendlyPages.forbiddenPageTemplate | default ( include "defaultForbiddenPage" . ) | indent 4 }}
   login-page: |
-{{ .Values.proxyOptions.loginPageTemplate | default ( include "defaultLoginPage" . ) | indent 4 }}
+{{ .Values.proxyOptions.userFriendlyPages.loginPageTemplate | default ( include "defaultLoginPage" . ) | indent 4 }}
 ...

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "auth-proxy.fullname" . }}-page-templates
+  name: {{ include "keycloak-gatekeeper.fullname" . }}-page-templates
   labels:
-{{ include "auth-proxy.labels" . | indent 4 }}
+{{ include "keycloak-gatekeeper.labels" . | indent 4 }}
 data:
   forbidden-page: |
 {{ .Values.proxyOptions.userFriendlyPages.forbiddenPageTemplate | default ( include "defaultForbiddenPage" . ) | indent 4 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,17 +2,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "auth-proxy.fullname" . }}
+  name: {{ include "keycloak-gatekeeper.fullname" . }}
 spec:
   replicas: 1
   revisionHistoryLimit: 0
   selector:
     matchLabels:
-{{ include "auth-proxy.labels" . | indent 6 }}
+{{ include "keycloak-gatekeeper.labels" . | indent 6 }}
   template:
     metadata:
       labels:
-{{ include "auth-proxy.labels" . | indent 8 }}
+{{ include "keycloak-gatekeeper.labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
@@ -75,5 +75,5 @@ spec:
       volumes:
       - name: page-templates
         configMap:
-          name: {{ include "auth-proxy.fullname" . }}-page-templates
+          name: {{ include "keycloak-gatekeeper.fullname" . }}-page-templates
 ...

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -33,9 +33,13 @@ spec:
         - --client-id={{ .Values.oidc.clientId | required "oidc.clientId not set" }}
         - --client-secret={{ .Values.oidc.clientSecret | required "oidc.clientSecret not set" }}
         - --discovery-url={{ .Values.oidc.discoveryUrl | required "oidc.discoveryUrl not set" }}
-        - --upstream-url=http://{{ .Values.upstreamServiceName | required "upstreamServiceName not set" }}
+        - --upstream-url={{ .Values.upstreamUrl | required "upstreamUrl not set" }}
+        {{- if .Values.proxyOptions.userFriendlyPages.enableLoginPage }}
         - --sign-in-page=/opt/templates/sign_in.html.tmpl
+        {{- end }}
+        {{- if .Values.proxyOptions.userFriendlyPages.enableForbiddenPage }}
         - --forbidden-page=/opt/templates/forbidden.html.tmpl
+        {{- end }}
         - --enable-session-cookies
         - --http-only-cookie=true
         - --preserve-host=true
@@ -57,7 +61,7 @@ spec:
         - --verbose
         {{- end }}
 
-        {{- if not .Values.proxyOptions.useUpstreamPageTemplates }}
+        {{- if not .Values.proxyOptions.userFriendlyPages.useUpstreamTemplates }}
         volumeMounts:
         - name: page-templates
           mountPath: /opt/templates/forbidden.html.tmpl

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,13 +1,13 @@
 ---
 {{- if .Values.ingress.enabled }}
-{{- $fullname := include "auth-proxy.fullname" . -}}
+{{- $fullname := include "keycloak-gatekeeper.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullname }}
   labels:
-{{ include "auth-proxy.labels" . | indent 4 }}
+{{ include "keycloak-gatekeeper.labels" . | indent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "auth-proxy.fullname" . }}
+  name: {{ include "keycloak-gatekeeper.fullname" . }}
   labels:
-{{ include "auth-proxy.labels" . | indent 4 }}
+{{ include "keycloak-gatekeeper.labels" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -13,5 +13,5 @@ spec:
       name: http
       targetPort: http
   selector:
-{{ include "auth-proxy.labels" . | indent 4 }}
+{{ include "keycloak-gatekeeper.labels" . | indent 4 }}
 ...

--- a/values.yaml
+++ b/values.yaml
@@ -1,14 +1,14 @@
-# Default values for auth-proxy.
+# Default values for keycloak-gatekeeper.
 
 image:
   name: keycloak/keycloak-gatekeeper
-  tag: 4.6.0.Final
+  tag: 5.0.0
   pullPolicy: IfNotPresent
 
 # Labels to be applied to all objects of this chart
 extraLabels: {}
 
-# Service pointing internally to the auth-proxy
+# Service pointing internally to the keycloak-gatekeeper
 service:
   type: ClusterIP
   port: 80
@@ -16,7 +16,7 @@ service:
 # URL that this proxy will forward requests to
 upstreamUrl: ""
 
-# Enable if you want to access the auth-proxy from the external world, through the ingress-controller
+# Enable if you want to access the keycloak-gatekeeper from the external world, through the ingress-controller
 ingress:
   enabled: false
   annotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,8 @@
 # Default values for auth-proxy.
 
 image:
-  name: quay.io/gambol99/keycloak-proxy
-  tag: v2.3.0
+  name: keycloak/keycloak-gatekeeper
+  tag: 4.6.0.Final
   pullPolicy: IfNotPresent
 
 # Labels to be applied to all objects of this chart
@@ -13,8 +13,8 @@ service:
   type: ClusterIP
   port: 80
 
-# Service that this proxy will forward requests to
-upstreamServiceName: ""
+# URL that this proxy will forward requests to
+upstreamUrl: ""
 
 # Enable if you want to access the auth-proxy from the external world, through the ingress-controller
 ingress:
@@ -48,7 +48,10 @@ proxyOptions:
   tokenEncryption: true
   # tokenEncryptionKey: ""
   enableHttpLogging: false
-  useUpstreamPageTemplates: false
-  forbiddenPageTemplate: ""
-  loginPageTemplate: ""
+  userFriendlyPages:
+    enableLoginPage: true
+    enableForbiddenPage: true
+    useUpstreamTemplates: false
+    forbiddenPageTemplate: ""
+    loginPageTemplate: ""
   verbose: false


### PR DESCRIPTION
- Rename project
- Generalize: specify any url as a backend, instead of a k8s service
- Update name of source image to keycloak/keycloak-gatekeeper
- Group user-facing pages parameters
- Fix docs